### PR TITLE
add `Task.completed/1`

### DIFF
--- a/lib/elixir/lib/task/completed.ex
+++ b/lib/elixir/lib/task/completed.ex
@@ -1,0 +1,52 @@
+defmodule Task.Completed do
+  @moduledoc """
+  Tasks are processes meant to execute one particular action throughout their lifetime,
+  often with little or no communication with other processes. In some cases, it is useful
+  to create a "completed" task that represents a task that has already run and generated
+  a result. For example, when processing data you may be able to determine that certain
+  inputs are invalid before dispatching them for further processing:
+
+      def process(data) do
+        tasks =
+          for entry <- data do
+            if invalid_input?(entry) do
+              Task.completed({:error, :invalid_input})
+            else
+              Task.async(fn -> further_process(entry) end)
+            end
+          end
+
+        Task.await_many(tasks)
+      end
+
+  In many cases, `Task.completed/1` may be avoided in favor of returning the result directly.
+  You should generally only require this variant when working with mixed asynchrony, when
+  a group of inputs will be handled partially synchronously and partially asynchronously.
+  """
+
+  @doc """
+  A variant of the Task struct that represents a task with a known result.
+
+  It contains these fields:
+
+    * `:result` - the task's result
+
+    * `:ref` - a unique reference
+
+    * `:owner` - the PID of the process that created the task
+
+  """
+  @enforce_keys [:result, :ref, :owner]
+  defstruct result: nil, ref: nil, owner: nil
+
+  @typedoc """
+  A variant of the Task type that represents a task with a known result.
+
+  See `%Task.Completed{}` for information about each field of the structure.
+  """
+  @type t :: %__MODULE__{
+          result: any(),
+          ref: reference(),
+          owner: pid()
+        }
+end


### PR DESCRIPTION
This PR is a work in progress.

As suggested by [this thread](https://groups.google.com/g/elixir-lang-core/c/ickqmBBoSMk/m/SSZDTDpbAAAJ), this PR adds `Task.completed/1` for representing tasks with a known result. I've opted to create a new struct variant, `Task.Completed`, to make the different behaviour more explicit and prevent adding overhead to the existing `Task` struct for those who don't require this variant (which I imagine includes most use cases).

An alternate approach would be to extend the existing `Task` struct to represent both pending and completed tasks, but this is difficult due to Elixir's immutability. In mutable languages, it would be simple enough to model a task as something like

```
{
  ref: #<abc123>,
  status: pending | error | completed,
  result: ...
}
```

This doesn't translate well to Elixir, however. Take this simple example usage:

```
task = Task.async(fn -> :hello end)
Task.await(task)
```

This represents typical usage, but note that the return value of `Task.await` is discarded, so we have no way of updating the task struct to represent that its `status` has changed from `pending` to `success`, nor to update its `result` value to `:hello`. As such, we would need two additional fields to differentiate "real" tasks (that need a linked process to execute) and "completed" tasks that already know their result. This would require expanding the `Task` struct to something like

```
%Task{
  pid: pid() | nil,
  ref: reference(),
  owner: pid(),
  variant: :linked_process | :completed,
  result: any()
}
```

and then conditionally

- listening for a message if it's the `:linked_process` variant, or
- returning `task.result` directly for the `:completed` variant

IMO the separate `Task.Completed` struct approach is cleaner, and has the added benefit of not requiring existing `Task` usage to change.

# TODO

- [ ] update tests
- [ ] improve documentation